### PR TITLE
Install dependencies  in proper order

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -1,8 +1,15 @@
 sudo apt-get update
+sudo apt-get install sbcl
 sudo apt-get install emacs
 sudo apt-get install slime
 sudo apt-get install libjpeg-progs
 sudo apt-get install  gif2png
+
+curl -O https://beta.quicklisp.org/quicklisp.lisp
+curl -O https://beta.quicklisp.org/quicklisp.lisp.asc
+gpg --verify quicklisp.lisp.asc quicklisp.lisp
+sbcl --load quicklisp.lisp
+
 cd ~/quicklisp/local-projects
 git clone https://github.com/vtomole/closure.git
 git clone https://github.com/robert-strandh/McCLIM.git
@@ -12,9 +19,4 @@ git clone https://github.com/sionescu/bordeaux-threads.git
 git clone https://github.com/bluelisp/zip.git
 git clone git://repo.or.cz/closure-html.git
 git clone https://github.com/edicl/flexi-streams.git
-curl -O https://beta.quicklisp.org/quicklisp.lisp
-curl -O https://beta.quicklisp.org/quicklisp.lisp.asc
-gpg --verify quicklisp.lisp.asc quicklisp.lisp
-sbcl --load quicklisp.lisp
-
 


### PR DESCRIPTION
Hi! Thanks for picking up this project! I've tested clean install on ubuntu kvm and here are few parts missing.

sbcl is an obvious dependency and quicklisp needs to be installed before cloning dependencies since local-projects does not exist without it.